### PR TITLE
Corrected inconsistent spacing, "fixed" race condition

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,16 +9,18 @@ console.debug("CloudShark Chrome Extension Loaded");
 // selects something from the context menu
 var elementClicked = null
 document.addEventListener("mousedown", function(event){
+  var enable = false;
   elementClicked = event.target;
- 	sendMessage("disable");
-	var node = elementClicked;
-	while (node != null) {
-  	if (node.id == "captures") {
-			sendMessage("enable");
-      return;
+  var node = elementClicked;
+  while (node != null) {
+    if (node.id == "captures") {
+      enable = true;
+      break;
     }
     node = node.parentNode;
-	}
+  }
+
+  sendMessage(enable ? "enable" : "disable");
 }, true);
 
 function getCaptureID() {

--- a/main.js
+++ b/main.js
@@ -49,22 +49,22 @@ function goToResponse(info, tab) {
 }
 
 function disableButtons() {
-	for (b in buttons) {
-		chrome.contextMenus.update(buttons[b], { enabled: false, });
-	}
+  for (b in buttons) {
+    chrome.contextMenus.update(buttons[b], { enabled: false, });
+  }
 }
 
 function enableButtons() {
-	for (b in buttons) {
-		chrome.contextMenus.update(buttons[b], { enabled: true, });
-	}
+  for (b in buttons) {
+    chrome.contextMenus.update(buttons[b], { enabled: true, });
+  }
 }
 
 // Listen for message from content script
 chrome.runtime.onMessage.addListener(function(message) {
-	if(message == "enable") {
-		enableButtons();
-	} else {
-		disableButtons();
-	}
+  if(message == "enable") {
+    enableButtons();
+  } else {
+    disableButtons();
+  }
 });


### PR DESCRIPTION
Since message passing is asynchronous, there is a race condition
on disabling and then re-enabling the menu quickly that was causing
issues in my browser. This fix has consistent behavior, but the
first click on a matching element will not enable the menu before
it becomes visisble, and the first click on a not-matching element
will not hide the menu before it becomes visible.